### PR TITLE
Fixes for the jaeger propagation header processing.

### DIFF
--- a/jaeger.go
+++ b/jaeger.go
@@ -189,8 +189,9 @@ var _ trace.Exporter = (*Exporter)(nil)
 
 // ExportSpan exports a SpanData to Jaeger.
 func (e *Exporter) ExportSpan(data *trace.SpanData) {
-	e.bundler.Add(spanDataToThrift(data), 1)
-	// TODO(jbd): Handle oversized bundlers.
+	if data.IsSampled() {
+		e.bundler.Add(spanDataToThrift(data), 1)
+	}
 }
 
 // As per the OpenCensus Status code mapping in

--- a/propagation/http.go
+++ b/propagation/http.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -28,7 +29,7 @@ import (
 )
 
 const (
-	httpHeader   = `uber-trace-id`
+	httpHeader   = `Uber-Trace-Id`
 	maxLenHeader = 200
 )
 
@@ -46,9 +47,14 @@ func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanCon
 		return trace.SpanContext{}, false
 	}
 
+	h, err := url.QueryUnescape(h)
+	if err != nil {
+		return trace.SpanContext{}, false
+	}
+
 	// Parse the trace id field.
 	traceHeaderParts := strings.Split(h, `:`)
-	if len(traceHeaderParts) != 4 {
+	if len(traceHeaderParts) != 4 && len(traceHeaderParts) != 3 {
 		return trace.SpanContext{}, false
 	}
 
@@ -68,7 +74,7 @@ func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanCon
 	}
 	copy(sc.SpanID[:], spanID)
 
-	opt, err := strconv.Atoi(traceHeaderParts[3])
+	opt, err := strconv.Atoi(traceHeaderParts[len(traceHeaderParts)-1])
 
 	if err != nil {
 		return trace.SpanContext{}, false


### PR DESCRIPTION
Some of these fixes align the library with Jaeger's native Go client.

- url.Decode the trace header .
- Support a 3 part trace header, the opencensus-java jaeger client seems to
  send these.
- Don't include respect the context if it is not sampled (without this,
  OpenCensus seems to send all traces to the agent, thus ignoring
  sampling).

Signed-off-by: Tristan Colgate <tristan@qubit.com>