### PR TITLE
Use golang 1.15 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go_import_path: contrib.go.opencensus.io
 
 go:
-  - 1.11.x
+  - 1.15.x
 
 env:
   global:


### PR DESCRIPTION
Golang version in Travis is too old, it's not supported anymore. Let's bump to 1.15